### PR TITLE
Fix registration application list

### DIFF
--- a/src/components/ApprovalsList.jsx
+++ b/src/components/ApprovalsList.jsx
@@ -126,12 +126,12 @@ function ApplicationListItem({ registration }) {
               <SquareChip
                 color="primary"
                 variant="outlined"
-                tooltip={registration.creator_local_user.validator_time}
+                tooltip={registration.creator.published}
                 tooltipPlacement="bottom"
               >
                 registered{" "}
                 <MomentAdjustedTimeAgo fromNow>
-                  {registration.creator_local_user.validator_time}
+                  {registration.creator.published}
                 </MomentAdjustedTimeAgo>
               </SquareChip>
             )}


### PR DESCRIPTION
In b02a676bebd2cb4ebb24473eec678136424bbd19 the registration application list was changed to use the `validator_time` of the local user instead of the `published` time of the person. The `validator_time` is no longer present in the Lemmy API, which broke the current implementation. This reverts the logic back to using just the person's `published` timestamp.

fixes #37